### PR TITLE
Add script to scrape water temperatures every 30 minutes

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,0 +1,2 @@
+# Cron job to run the scrape_temperatures.R script every 30 minutes
+*/30 * * * * Rscript /path/to/your/script/scrape_temperatures.R

--- a/scrape_temperatures.R
+++ b/scrape_temperatures.R
@@ -1,0 +1,28 @@
+library(rvest)
+library(dplyr)
+
+# URL of the webpage to scrape
+url <- "https://www.stadt-zuerich.ch/ssd/de/index/sport/schwimmen/wassertemperaturen.html"
+
+# Function to scrape data
+scrape_data <- function() {
+  # Read the HTML content from the URL
+  webpage <- read_html(url)
+  
+  # Extract the relevant temperature data for "Anlage und Gäste"
+  data <- webpage %>%
+    html_nodes(xpath = '//*[@id="content"]/div[2]/div[2]/div[2]/div[2]/table') %>%
+    html_table()
+  
+  # Convert the extracted data to a data frame
+  df <- data[[1]]
+  
+  # Add a timestamp column
+  df$timestamp <- Sys.time()
+  
+  # Save the data to a CSV file
+  write.table(df, file = "wassertemperaturen.csv", sep = ",", row.names = FALSE, col.names = !file.exists("wassertemperaturen.csv"), append = TRUE)
+}
+
+# Scrape data
+scrape_data()


### PR DESCRIPTION
Add script to scrape data from the specified URL every 30 minutes and save it as a CSV file.

* **scrape_temperatures.R**
  - Create a new script to scrape data from `https://www.stadt-zuerich.ch/ssd/de/index/sport/schwimmen/wassertemperaturen.html`
  - Use the `rvest` package to extract the relevant temperature data for "Anlage und Gäste"
  - Save the extracted data to a CSV file named `wassertemperaturen.csv`
  - Append new data to the CSV file if it already exists

* **crontab**
  - Add a cron job to run the `scrape_temperatures.R` script every 30 minutes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DavidSimonRothschild/David-s-Data-Insights?shareId=55b0280b-0697-4eb8-a6f5-cba5d1a2e673).